### PR TITLE
feat(docker): upgrade pip and install dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-RUN pip install psycopg2-binary
-RUN pip install mlflow
+RUN pip install --upgrade pip \
+    psycopg2-binary \
+    mlflow
 
 EXPOSE 5000
 

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
         "app.api:create_app",
         factory=True,
         host="0.0.0.0",
-        port=int(os.getenv("PORT", 8084)),
+        port=int(os.getenv("PORT", 8080)),
         reload=True,
     )
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+    "version": 2,
+    "builds": [{ "src": "app/__main__.py", "use": "@vercel/python" }],
+    "routes": [
+        { "src": "/(.*)",
+          "dest": "app/__main__.py",
+          "headers": {
+            "Access-Control-Allow-Credentials": "true",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET, POST",
+            "Access-Control-Allow-Headers": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
- Upgrade pip before installing psycopg2-binary and mlflow.
- Change default port from 8084 to 8080 in the main application.
- Add vercel.json configuration for deployment.